### PR TITLE
Remove rate limits from config; require client_id

### DIFF
--- a/kong/plugins/sm-account-rate-limiting/handler.lua
+++ b/kong/plugins/sm-account-rate-limiting/handler.lua
@@ -108,12 +108,12 @@ function RateLimitingHandler:access(conf)
 
     -- Load current metric for configured period
     local usage, stop, err = get_usage(conf, client_id, account_id, current_timestamp, {
-      second = conf.second,
-      minute = conf.minute,
-      hour = conf.hour,
-      day = conf.day,
-      month = conf.month,
-      year = conf.year})
+      second = rate_limits.second,
+      minute = rate_limits.minute,
+      hour = rate_limits.hour,
+      day = rate_limits.day,
+      month = rate_limits.month,
+      year = rate_limits.year})
     if err then
         if fault_tolerant then
             ngx.log(ngx.ERR, "failed to get usage: ", tostring(err))

--- a/kong/plugins/sm-account-rate-limiting/schema.lua
+++ b/kong/plugins/sm-account-rate-limiting/schema.lua
@@ -2,43 +2,13 @@ local Errors = require "kong.dao.errors"
 
 return {
   fields = {
-    second = { type = "number" },
-    minute = { type = "number" },
-    hour = { type = "number" },
-    day = { type = "number" },
-    month = { type = "number" },
-    year = { type = "number" },
     client_id = { type = "string" },
     policy = { type = "string", enum = {"cluster"}, default = "cluster" },  -- currently, the only accepted policy is "cluster", but we can add other back in if needed
     fault_tolerant = { type = "boolean", default = true }
   },
   self_check = function(schema, plugin_t, dao, is_update)
-    local ordered_periods = { "second", "minute", "hour", "day", "month", "year"}
-    local has_value
-    local invalid_order
-    local invalid_value
-
-    for i, v in ipairs(ordered_periods) do
-      if plugin_t[v] then
-        has_value = true
-        if plugin_t[v] <=0 then
-          invalid_value = "Value for "..v.." must be greater than zero"
-        else
-          for t = i+1, #ordered_periods do
-            if plugin_t[ordered_periods[t]] and plugin_t[ordered_periods[t]] < plugin_t[v] then
-              invalid_order = "The limit for "..ordered_periods[t].." cannot be lower than the limit for "..v
-            end
-          end
-        end
-      end
-    end
-
-    if not has_value then
-      return false, Errors.schema "You need to set at least one limit: second, minute, hour, day, month, year"
-    elseif invalid_value then
-      return false, Errors.schema(invalid_value)
-    elseif invalid_order then
-      return false, Errors.schema(invalid_order)
+    if not plugin_t['client_id'] then
+      return false, Errors.schema "This plugin requires a client ID"
     end
 
     return true


### PR DESCRIPTION
@simplymeasured/team-narwhal 
 FA-71
For account rate limiting, the rate limits are located on the JWT, so
there is no need to pass them in via the plugin config.
Also, we need to require that client_id is specified, as this plugin is
intended to only rate limit API consumers.