### PR TITLE
Emit rate-limiting debuging messages to debug.

### DIFF
--- a/kong/plugins/sm-account-rate-limiting/handler.lua
+++ b/kong/plugins/sm-account-rate-limiting/handler.lua
@@ -59,7 +59,7 @@ local function get_usage(conf, client_id, account_id, current_timestamp, limits)
             return nil, nil, err
         end
 
-        ngx.log(ngx.NOTICE, " current_usage:  "..current_usage)
+        ngx.log(ngx.DEBUG, " current_usage:  "..current_usage)
         -- What is the current usage for the configured limit name?
         local remaining = limit - current_usage
 
@@ -69,7 +69,7 @@ local function get_usage(conf, client_id, account_id, current_timestamp, limits)
             remaining = remaining
         }
 
-        ngx.log(ngx.NOTICE, "Limit:  "..limit.."  Remaining:  "..remaining)
+        ngx.log(ngx.DEBUG, "Limit:  "..limit.."  Remaining:  "..remaining)
 
         if remaining <= 0 then
             stop = name

--- a/kong/plugins/sm-account-rate-limiting/policies/cluster.lua
+++ b/kong/plugins/sm-account-rate-limiting/policies/cluster.lua
@@ -19,7 +19,7 @@ return {
       end
 
       local query = concat(buf, ";")
-      ngx.log(ngx.NOTICE, "querying postgres for "..query)
+      ngx.log(ngx.DEBUG, "querying postgres for "..query)
 
       local res, err = db:query(query)
       if not res then return nil, err end
@@ -38,7 +38,7 @@ return {
               period = '%s'
       ]], client_id, account_id, periods[period]/1000, period)
 
-      ngx.log(ngx.NOTICE, "querying postgres for "..query)
+      ngx.log(ngx.DEBUG, "querying postgres for "..query)
 
       local response, err = db:query(query)
       if not response or err then return nil, err end


### PR DESCRIPTION
Quite a bit of noise in production on many requests. NOTICE is pretty high for this kind of thing, RFC 5424 differentiates NOTICE as being a "normal but significant condition." 
 
Can always lower error log squelch level if we need to see them in particular environments. 

Thoughts? 